### PR TITLE
Deauthenticate station on VXLAN setup failure

### DIFF
--- a/src/EventLoop.cpp
+++ b/src/EventLoop.cpp
@@ -34,15 +34,16 @@ void EventLoop::handle_auth(ipc::AuthEvent* event) {
 void EventLoop::handle_assoc(ipc::AssocEvent* event) {
     event->station.vlan_id = caller.vlan_for_station(event->station.mac);
     WMLOG(DEBUG) << "handle_assoc called " << event->station.mac << " with vlan_id "
-                    << event->station.vlan_id.value_or(0);
+                 << event->station.vlan_id.value_or(0);
     WMLOG(INFO) << "Station " << event->station.mac << " connected to AP for VXLAN " << event->station.vni();
     try {
         renderer.setup_station(event->station);
         processing_time_histogram.Observe(event->finished_processing());
     } catch (std::runtime_error& err) {
-        WMLOG(ERROR) << "station could not be bridged to vxlan interface: " << err.what();
+        WMLOG(ERROR) << "station could not be bridged to vxlan interface: " << err.what()
+                     << " - Will now send deauth packet";
+        caller.deauth_station(event->station.mac);
     }
-    // TODO: Disconnect station on bridging failure
 }
 
 void EventLoop::handle_disassoc(ipc::DisassocEvent* event) {

--- a/src/ipc/Caller.cpp
+++ b/src/ipc/Caller.cpp
@@ -43,4 +43,4 @@ void ipc::Caller::deauth_station(const std::string &station_mac) {
     if (result != "OK") {
         WMLOG(WARNING) << "Did not receive OK on DEAUTH request: " << result;
     }
-};
+}

--- a/src/ipc/Caller.cpp
+++ b/src/ipc/Caller.cpp
@@ -36,3 +36,7 @@ std::vector<Station> ipc::Caller::connected_stations() {
     }
     return stations;
 }
+
+void ipc::Caller::deauth_station(const std::string &station_mac) {
+    socket.send_and_receive({"DEAUTHENTICATE", station_mac});
+};

--- a/src/ipc/Caller.cpp
+++ b/src/ipc/Caller.cpp
@@ -9,6 +9,7 @@
 #include "../logging/loginit.h"
 
 const std::string VLAN_ID_PREFIX = "vlan_id=";
+const std::string HOSTAPD_OK = "OK\n";
 
 ipc::Caller::Caller() : socket(std::chrono::seconds(1)) {}
 
@@ -40,7 +41,7 @@ std::vector<Station> ipc::Caller::connected_stations() {
 
 void ipc::Caller::deauth_station(const std::string &station_mac) {
     std::string result = socket.send_and_receive({"DEAUTHENTICATE", station_mac});
-    if (result != "OK") {
+    if (result != HOSTAPD_OK) {
         WMLOG(WARNING) << "Did not receive OK on DEAUTH request: " << result;
     }
 }

--- a/src/ipc/Caller.cpp
+++ b/src/ipc/Caller.cpp
@@ -6,6 +6,7 @@
 #include <thread>
 
 #include "../Station.h"
+#include "../logging/loginit.h"
 
 const std::string VLAN_ID_PREFIX = "vlan_id=";
 
@@ -38,5 +39,8 @@ std::vector<Station> ipc::Caller::connected_stations() {
 }
 
 void ipc::Caller::deauth_station(const std::string &station_mac) {
-    socket.send_and_receive({"DEAUTHENTICATE", station_mac});
+    std::string result = socket.send_and_receive({"DEAUTHENTICATE", station_mac});
+    if (result != "OK") {
+        WMLOG(WARNING) << "Did not receive OK on DEAUTH request: " << result;
+    }
 };

--- a/src/ipc/Caller.cpp
+++ b/src/ipc/Caller.cpp
@@ -9,7 +9,6 @@
 #include "../logging/loginit.h"
 
 const std::string VLAN_ID_PREFIX = "vlan_id=";
-const std::string HOSTAPD_OK = "OK\n";
 
 ipc::Caller::Caller() : socket(std::chrono::seconds(1)) {}
 
@@ -41,7 +40,7 @@ std::vector<Station> ipc::Caller::connected_stations() {
 
 void ipc::Caller::deauth_station(const std::string &station_mac) {
     std::string result = socket.send_and_receive({"DEAUTHENTICATE", station_mac});
-    if (result != HOSTAPD_OK) {
+    if (result != Socket::HOSTAPD_OK) {
         WMLOG(WARNING) << "Did not receive OK on DEAUTH request: " << result;
     }
 }

--- a/src/ipc/Caller.h
+++ b/src/ipc/Caller.h
@@ -9,9 +9,10 @@ class Caller {
    public:
     Caller();
 
-    uint32_t vlan_for_station(const std::string &station_mac);
+    uint32_t vlan_for_station(const std::string& station_mac);
 
     std::vector<Station> connected_stations();
+    void deauth_station(const std::string& station_mac);
 
    private:
     Socket socket;

--- a/src/ipc/Socket.h
+++ b/src/ipc/Socket.h
@@ -23,6 +23,8 @@ class Socket {
 
     std::string receive() const;
 
+    inline static const std::string HOSTAPD_OK = "OK\n";
+
     ~Socket();
 
    private:

--- a/src/ipc/Subscriber.cpp
+++ b/src/ipc/Subscriber.cpp
@@ -23,7 +23,7 @@ ipc::Subscriber::Subscriber(SynchronizedQueue<Event>& queue, const std::chrono::
 
 void ipc::Subscriber::loop(const std::future<void>& future) {
     std::string result = socket.send_and_receive({"ATTACH"});
-    if (result != "OK\n") {
+    if (result != Socket::HOSTAPD_OK) {
         throw std::runtime_error(std::string("could not attach to hostapd: ") + result);
     }
     WMLOG(INFO) << "attached to hostapd";

--- a/src/nl/Socket.h
+++ b/src/nl/Socket.h
@@ -21,6 +21,7 @@ class Socket {
     void create_bridge(const std::string& name);
     void delete_interface(const std::string& name);
     std::unordered_set<uint32_t> interface_list();
+
    private:
     struct nl_sock* socket;
 };


### PR DESCRIPTION
Closes #21 

- When a station cannot be properly set up, we send a deauth packet via hostAPD.