### PR TITLE
Handle comments and lines without equals sign

### DIFF
--- a/src/ConfigParser.cpp
+++ b/src/ConfigParser.cpp
@@ -39,7 +39,7 @@ ConfigParser::ConfigParser(std::istream &istream) {
     std::string delimiter = "=";
     while (std::getline(istream, line, '\n')) {
         auto split = line.find(delimiter);
-        if (line.starts_with("#") || line.size() == 0) {
+        if (line.starts_with("#") || line.empty()) {
             continue;
         }
         if (split == std::string::npos) {

--- a/src/ConfigParser.cpp
+++ b/src/ConfigParser.cpp
@@ -38,14 +38,14 @@ ConfigParser::ConfigParser(std::istream &istream) {
     std::string line;
     std::string delimiter = "=";
     while (std::getline(istream, line, '\n')) {
-        auto split = line.find(delimiter);
+        trim(line);
         if (line.starts_with("#") || line.empty()) {
             continue;
         }
+        auto split = line.find(delimiter);
         if (split == std::string::npos) {
             throw std::runtime_error("Configuration line is invalid: " + line);
         }
-        trim(line);
         std::string token = line.substr(0, split);
         trim(token);
         // Make token lowercase

--- a/src/ConfigParser.cpp
+++ b/src/ConfigParser.cpp
@@ -39,6 +39,12 @@ ConfigParser::ConfigParser(std::istream &istream) {
     std::string delimiter = "=";
     while (std::getline(istream, line, '\n')) {
         auto split = line.find(delimiter);
+        if (line.starts_with("#") || line.size() == 0) {
+            continue;
+        }
+        if (split == std::string::npos) {
+            throw std::runtime_error("Configuration line is invalid: " + line);
+        }
         trim(line);
         std::string token = line.substr(0, split);
         trim(token);

--- a/test/configuration_test.cpp
+++ b/test/configuration_test.cpp
@@ -68,3 +68,12 @@ TEST(ConfigurationTest, ValueSpacingIgnored) {
     Configuration& config = ConfigurationTest::from_string("hapd_group= network ");
     ASSERT_EQ(config.hapd_group, "network");
 }
+
+TEST(ConfigurationTest, MissingEqualsTest) {
+    EXPECT_THROW({ Configuration& config = ConfigurationTest::from_string("hapd_group"); }, std::runtime_error);
+}
+
+TEST(ConfigurationTest, CommentTest) {
+    Configuration& config = ConfigurationTest::from_string("hapd_group=network\n# TestComment");
+    ASSERT_EQ(config.hapd_group, "network");
+}

--- a/test/configuration_test.cpp
+++ b/test/configuration_test.cpp
@@ -70,7 +70,7 @@ TEST(ConfigurationTest, ValueSpacingIgnored) {
 }
 
 TEST(ConfigurationTest, MissingEqualsTest) {
-    EXPECT_THROW({ Configuration& config = ConfigurationTest::from_string("hapd_group"); }, std::runtime_error);
+    EXPECT_THROW({ ConfigurationTest::from_string("hapd_group"); }, std::runtime_error);
 }
 
 TEST(ConfigurationTest, CommentTest) {


### PR DESCRIPTION
Solves #38 
- Throws an error when there is a line without an equals sign
- Skips the line when it starts with a `#` or is empty