### PR TITLE
47 run linting formatting and testing in parallel

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -87,6 +87,7 @@ Checks: >
   -modernize-use-nodiscard,
   -modernize-use-trailing-return-type,
   -readability-identifier-length,
+  -bugprone-suspicious-include,
   hicpp-exception-baseclass,
   hicpp-multiway-paths-covered,
   hicpp-no-assembler,

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Start CMake
-        run: cmake CMakeLists.txt
+        run: cmake CMakeLists.txt -DCMAKE_UNITY_BUILD=ON -DCMAKE_UNITY_BUILD_BATCH_SIZE=0
       - name: Start linting
         run: make lint
   testing:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,22 +1,33 @@
-name: Run clang linter
+name: Run checks
 
 on:
   push:
 
 jobs:
-  linting-formatting:
+  formatting:
     runs-on: ubuntu-latest
+    container: ghcr.io/wimove-oss/wimove-testimage:latest
     steps:
       - uses: actions/checkout@v3
-      - name: Clone and build prometheus-cpp
-        run: git clone https://github.com/jupp0r/prometheus-cpp.git && cd prometheus-cpp && git submodule init && git submodule update && mkdir _build && cd _build && cmake .. -DBUILD_SHARED_LIBS=ON -DENABLE_PUSH=OFF -DENABLE_COMPRESSION=OFF && cmake --build . --parallel 4 && ctest -V && sudo cmake --install .
-      - name: Install libnl
-        run: sudo apt-get update && sudo apt-get install libnl-3-dev libnl-route-3-dev
       - name: Start CMake
         run: cmake CMakeLists.txt
       - name: Start formatting
         run: make format-check
-      - name: Test
-        run: make test
+  linting:
+    runs-on: ubuntu-latest
+    container: ghcr.io/wimove-oss/wimove-testimage:latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Start CMake
+        run: cmake CMakeLists.txt
       - name: Start linting
         run: make lint
+  testing:
+    runs-on: ubuntu-latest
+    container: ghcr.io/wimove-oss/wimove-testimage:latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Start CMake
+        run: cmake CMakeLists.txt
+      - name: Test
+        run: make test

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Start CMake
         run: cmake CMakeLists.txt -DCMAKE_UNITY_BUILD=ON -DCMAKE_UNITY_BUILD_BATCH_SIZE=0
       - name: Start linting
-        run: make lint
+        run: make unity-lint
   testing:
     runs-on: ubuntu-latest
     container: ghcr.io/wimove-oss/wimove-testimage:latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ add_custom_target(test DEPENDS wimoved_tests COMMAND ./wimoved_tests)
 add_custom_target(format COMMAND clang-format -i ${SRC_FILES} ${TEST_FILES})
 add_custom_target(format-check COMMAND clang-format --dry-run --Werror ${SRC_FILES} ${TEST_FILES})
 add_custom_target(lint COMMAND run-clang-tidy -j8 -quiet ${SRC_FILES} ${TEST_FILES})
+add_custom_target(unity-lint COMMAND run-clang-tidy -quiet -p . CMakeFiles/wimoved.dir/ )
 add_custom_target(precommit DEPENDS format test lint)
 install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION bin)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ add_custom_target(test DEPENDS wimoved_tests COMMAND ./wimoved_tests)
 add_custom_target(format COMMAND clang-format -i ${SRC_FILES} ${TEST_FILES})
 add_custom_target(format-check COMMAND clang-format --dry-run --Werror ${SRC_FILES} ${TEST_FILES})
 add_custom_target(lint COMMAND run-clang-tidy -j8 -quiet ${SRC_FILES} ${TEST_FILES})
-add_custom_target(unity-lint COMMAND run-clang-tidy -quiet -p . CMakeFiles/wimoved.dir/ )
+add_custom_target(unity-lint COMMAND run-clang-tidy -quiet -p . CMakeFiles/wimoved.dir/ CMakeFiles/wimoved_tests.dir/)
 add_custom_target(precommit DEPENDS format test lint)
 install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION bin)
 


### PR DESCRIPTION
I introduced unity builds for linting. Inspired by [this article](https://www.methodpark.de/blog/how-to-speed-up-clang-tidy-with-unity-builds/), unity builds make linting faster by parsing the headers less often. It was necessary to disable one check, because the generated unity build file makes suspicious includes. But I think the tradeoff is worth it, because linting now only takes 1 minute in comparison to over five.