### PR TITLE
Use proper OpenWrt spelling

### DIFF
--- a/.github/workflows/build-openwrt.yml
+++ b/.github/workflows/build-openwrt.yml
@@ -1,4 +1,4 @@
-name: Build OpenWRT Image
+name: Build OpenWrt Image
 
 on:
   workflow_call:
@@ -52,7 +52,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.ghtoken }}
-      - name: Build OpenWRT
+      - name: Build OpenWrt
         run: export IMAGE="ghcr.io/wimove-oss/wimove/wimove-buildenv/${{ inputs.architecture }}:${{ env.BRANCH }}" && chmod +x ./scripts/build-gha.sh && ./scripts/build-gha.sh
       - uses: actions/upload-artifact@v3
         with:

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ WiMoVE is built with standard network protocols, on top of open&#8209;source tec
 
 - The overlay networks use [BGP EVPN](https://www.rfc-editor.org/rfc/rfc8365.html) with [VXLAN](https://www.rfc-editor.org/rfc/rfc7348) encapsulation.
 - All BGP speakers run [FRRouting](https://frrouting.org/) to exchange EVPN routes.
-- The access points run [OpenWRT](https://openwrt.org/) with our custom, open&#8209;source daemon called [wimoved](https://github.com/wimove-oss/wimoved).
+- The access points run [OpenWrt](https://openwrt.org/) with our custom, open&#8209;source daemon called [wimoved](https://github.com/wimove-oss/wimoved).
 
-This solution allows for using commodity access points running OpenWRT for large&#8209;scale Wi&#8209;Fi deployments, even from different vendors.
+This solution allows for using commodity access points running OpenWrt for large&#8209;scale Wi&#8209;Fi deployments, even from different vendors.
 
 ## This repository
 
@@ -26,9 +26,9 @@ If you want to learn more about the architecture or create a full setup, take a 
 
 ## Supported architectures
 
-Currently, we support OpenWRT with the architectures `ramips-mt7621` and `mvebu-cortexa9`.
+Currently, we support OpenWrt with the architectures `ramips-mt7621` and `mvebu-cortexa9`.
 We test our software on the Access Point models `ZyXEL NWA50AX` and `Linksys WRT1900ACS`.
-If you need support for other OpenWRT architectures, feel free to open an issue.
+If you need support for other OpenWrt architectures, feel free to open an issue.
 
 ## Development setup
 

--- a/scripts/openwrtfiles/wimoved
+++ b/scripts/openwrtfiles/wimoved
@@ -1,5 +1,5 @@
 #!/bin/sh /etc/rc.common
-# Inspired by the procd example script of the OpenWRT wiki
+# Inspired by the procd example script of the OpenWrt wiki
 
 USE_PROCD=1
 START=99


### PR DESCRIPTION
The correct spelling seems to be `OpenWrt`. I adjusted our documentation, but there also a few misspells in this repository.