### PR TITLE
Fix MAC address parsing and serialization

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -87,6 +87,7 @@ Checks: >
   -modernize-use-nodiscard,
   -modernize-use-trailing-return-type,
   -readability-identifier-length,
+  -readability-function-cognitive-complexity,
   -bugprone-suspicious-include,
   hicpp-exception-baseclass,
   hicpp-multiway-paths-covered,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -57,6 +57,8 @@ CheckOptions:
     value: lower_case
   - key: readability-identifier-naming.VariableCase
     value: lower_case
+  - key: readability-function-cognitive-complexity.IgnoreMacros
+    value: 'true'
 Checks: >
   *,
   -abseil-*,
@@ -87,7 +89,6 @@ Checks: >
   -modernize-use-nodiscard,
   -modernize-use-trailing-return-type,
   -readability-identifier-length,
-  -readability-function-cognitive-complexity,
   -bugprone-suspicious-include,
   hicpp-exception-baseclass,
   hicpp-multiway-paths-covered,

--- a/src/MacAddress.cpp
+++ b/src/MacAddress.cpp
@@ -12,14 +12,15 @@ MacAddress::MacAddress(std::string serialized) : data(), serialized(serialized) 
     }
     serialized.erase(std::remove(serialized.begin(), serialized.end(), ':'), serialized.end());
     for (size_t i = 0; i < MAC_NUM_BYTES; i++) {
-        data[i] = std::strtoul(serialized.substr(2 * i, 2 * i + 2).c_str(), nullptr, MAC_OCTET_BASE);
+        data[i] = std::strtoul(serialized.substr(2 * i, 2).c_str(), nullptr, MAC_OCTET_BASE);
     }
 }
 std::string MacAddress::string() const { return serialized; }
 uint64_t MacAddress::number() const {
     uint64_t res = 0;
     for (size_t i = 0; i < MAC_NUM_BYTES; i++) {
-        res = res | data[i] << (BITS_PER_BYTE * i);
+        res <<= BITS_PER_BYTE;
+        res = res | data[i];
     }
     return res;
 }

--- a/test/mac_address_test.cpp
+++ b/test/mac_address_test.cpp
@@ -1,0 +1,25 @@
+#include <gtest/gtest-param-test.h>
+#include <gtest/gtest.h>
+
+#include "MacAddress.h"
+
+class MacAddressTest : public testing::TestWithParam<std::pair<std::string, uint64_t>> {};
+
+TEST_P(MacAddressTest, SerializedIsOriginal) {
+    auto [mac_address, number] = MacAddressTest::GetParam();
+    ASSERT_EQ(MacAddress(mac_address).string(), mac_address);
+}
+
+TEST_P(MacAddressTest, NumberCorrect) {
+    auto [mac_address, number] = MacAddressTest::GetParam();
+    ASSERT_EQ(MacAddress(mac_address).number(), number);
+}
+
+using test_pair = std::pair<std::string, uint64_t>;
+
+INSTANTIATE_TEST_SUITE_P(ExampleMacAddresses, MacAddressTest,
+                         testing::Values(test_pair{"00:00:00:00:00:00", 0}, test_pair{"00:00:00:00:00:01", 1},
+                                         test_pair{"00:00:00:00:00:0f", 15}, test_pair{"00:00:00:00:00:0F", 15},
+                                         test_pair{"00:00:00:00:00:20", 32}, test_pair{"00:00:00:00:04:00", 1024},
+                                         test_pair{"00:00:00:00:80:00", 32768},
+                                         test_pair{"01:00:00:00:00:00", 1099511627776}));

--- a/test/mac_address_test.cpp
+++ b/test/mac_address_test.cpp
@@ -3,23 +3,48 @@
 
 #include "MacAddress.h"
 
-class MacAddressTest : public testing::TestWithParam<std::pair<std::string, uint64_t>> {};
+using validation_test_pair = std::pair<std::string, bool>;
 
-TEST_P(MacAddressTest, SerializedIsOriginal) {
-    auto [mac_address, number] = MacAddressTest::GetParam();
+class MacAddressValidationTest : public testing::TestWithParam<validation_test_pair> {};
+
+TEST_P(MacAddressValidationTest, AddressValid) {
+    auto [mac_address, valid] = MacAddressValidationTest::GetParam();
+
+    if (valid) {
+        ASSERT_NO_THROW(MacAddress(mac_address).string());
+    } else {
+        ASSERT_THROW(MacAddress(mac_address).string(), std::runtime_error);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ExampleMacAddresses, MacAddressValidationTest,
+    testing::Values(validation_test_pair{"00:00:00:00:00:00", true}, validation_test_pair{"01:23:45:67:89:ab", true},
+                    validation_test_pair{"cd:ef:AB:CD:EF:00", true}, validation_test_pair{"00:00:00:00:00", false},
+                    validation_test_pair{"00:00:00:00:00:00:00", false},
+                    validation_test_pair{"0000:00:00:00:00", false}, validation_test_pair{"00:00:00:00:00:0", false},
+                    validation_test_pair{"00:00:00:00:00:0g", false}));
+
+using serialization_test_pair = std::pair<std::string, uint64_t>;
+
+class MacAddressSerializationTest : public testing::TestWithParam<serialization_test_pair> {};
+
+TEST_P(MacAddressSerializationTest, SerializedIsOriginal) {
+    auto [mac_address, number] = MacAddressSerializationTest::GetParam();
     ASSERT_EQ(MacAddress(mac_address).string(), mac_address);
 }
 
-TEST_P(MacAddressTest, NumberCorrect) {
-    auto [mac_address, number] = MacAddressTest::GetParam();
+TEST_P(MacAddressSerializationTest, NumberCorrect) {
+    auto [mac_address, number] = MacAddressSerializationTest::GetParam();
     ASSERT_EQ(MacAddress(mac_address).number(), number);
 }
 
-using test_pair = std::pair<std::string, uint64_t>;
-
-INSTANTIATE_TEST_SUITE_P(ExampleMacAddresses, MacAddressTest,
-                         testing::Values(test_pair{"00:00:00:00:00:00", 0}, test_pair{"00:00:00:00:00:01", 1},
-                                         test_pair{"00:00:00:00:00:0f", 15}, test_pair{"00:00:00:00:00:0F", 15},
-                                         test_pair{"00:00:00:00:00:20", 32}, test_pair{"00:00:00:00:04:00", 1024},
-                                         test_pair{"00:00:00:00:80:00", 32768},
-                                         test_pair{"01:00:00:00:00:00", 1099511627776}));
+INSTANTIATE_TEST_SUITE_P(ExampleMacAddresses, MacAddressSerializationTest,
+                         testing::Values(serialization_test_pair{"00:00:00:00:00:00", 0},
+                                         serialization_test_pair{"00:00:00:00:00:01", 1},
+                                         serialization_test_pair{"00:00:00:00:00:0f", 15},
+                                         serialization_test_pair{"00:00:00:00:00:0F", 15},
+                                         serialization_test_pair{"00:00:00:00:00:20", 32},
+                                         serialization_test_pair{"00:00:00:00:04:00", 1024},
+                                         serialization_test_pair{"00:00:00:00:80:00", 32768},
+                                         serialization_test_pair{"01:00:00:00:00:00", 1099511627776}));


### PR DESCRIPTION
Solves #46 

* Eliminate undefined behavior in `MacAddress::number`
* Use network byte order (big endian) for `MacAddress::number`
* Use correct length for `substr` in constructor
* Write validation and serialization tests

I blacklisted the rule `readability-function-cognitive-complexity` globally since it flagged the test case without a reason, but I don't know whether that is the right call.