### PR TITLE
Implement min_vni configuration option

### DIFF
--- a/src/ConfigParser.cpp
+++ b/src/ConfigParser.cpp
@@ -91,4 +91,5 @@ std::vector<std::string> ConfigParser::get_config_string_vector(const std::strin
 void ConfigParser::populate_configuration(Configuration &config) const {
     config.apply_config_file(*this);
     config.apply_environment();
+    config.check_validity();
 }

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -15,7 +15,7 @@ const uint32_t Configuration::DEFAULT_CLEANUP_INTERVAL = 10;
 
 const std::string HAPD_GLOBAL_SOCK_NAME = "global";
 
-Configuration Configuration::INSTANCE;
+Configuration Configuration::INSTANCE; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 static void set_string_if_valid(const ConfigParser& parser, std::string& config_target, const std::string& key) {
     try {

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -15,7 +15,7 @@ const uint32_t Configuration::DEFAULT_CLEANUP_INTERVAL = 10;
 
 const std::string HAPD_GLOBAL_SOCK_NAME = "global";
 
-Configuration Configuration::INSTANCE; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+Configuration Configuration::INSTANCE;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 static void set_string_if_valid(const ConfigParser& parser, std::string& config_target, const std::string& key) {
     try {

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -5,6 +5,7 @@
 #include "filesystem"
 #include "logging/loginit.h"
 
+const uint32_t Configuration::DEFAULT_MIN_VNI = 1;
 const uint32_t Configuration::DEFAULT_MAX_VNI = 20;
 const std::string Configuration::DEFAULT_HAPD_SOCKDIR = "/var/run/hostapd/";
 const std::string Configuration::DEFAULT_HAPD_GROUP = "root";
@@ -13,6 +14,8 @@ const std::vector<std::string> Configuration::DEFAULT_SOCKNAMES = {};
 const uint32_t Configuration::DEFAULT_CLEANUP_INTERVAL = 10;
 
 const std::string HAPD_GLOBAL_SOCK_NAME = "global";
+
+Configuration Configuration::INSTANCE;
 
 static void set_string_if_valid(const ConfigParser& parser, std::string& config_target, const std::string& key) {
     try {
@@ -55,8 +58,18 @@ void Configuration::apply_config_file(const ConfigParser& parser) {
     set_string_if_valid(parser, this->hapd_group, "hapd_group");
     set_string_if_valid(parser, this->log_path, "log_path");
     set_uint32_if_valid(parser, this->cleanup_interval, "cleanup_interval");
+    set_uint32_if_valid(parser, this->min_vni, "min_vni");
     set_uint32_if_valid(parser, this->max_vni, "max_vni");
     set_string_vector_if_valid(parser, this->socknames, "sockets");
 }
 
-void Configuration::apply_environment() { set_all_available_sockets_if_empty(); }
+void Configuration::apply_environment() {
+    set_all_available_sockets_if_empty();
+}
+
+void Configuration::check_validity() const {
+    if (min_vni > max_vni) {
+        throw std::runtime_error("min_vni must be less than or equal to max_vni " + std::to_string(min_vni) + " > " +
+                                 std::to_string(max_vni));
+    }
+}

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -63,9 +63,7 @@ void Configuration::apply_config_file(const ConfigParser& parser) {
     set_string_vector_if_valid(parser, this->socknames, "sockets");
 }
 
-void Configuration::apply_environment() {
-    set_all_available_sockets_if_empty();
-}
+void Configuration::apply_environment() { set_all_available_sockets_if_empty(); }
 
 void Configuration::check_validity() const {
     if (min_vni > max_vni) {

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -11,8 +11,12 @@ class Configuration {
    public:
     static Configuration& get_instance() { return INSTANCE; }
     static void reset() { INSTANCE = Configuration{}; }
+
     ~Configuration() = default;
     Configuration(Configuration const&) = delete;
+    Configuration(Configuration&&) = delete;
+    Configuration& operator=(Configuration const&) = delete;
+
     void apply_config_file(const ConfigParser& parser);
     void apply_environment();
     void check_validity() const;
@@ -36,8 +40,9 @@ class Configuration {
    private:
     Configuration() = default;
     void set_all_available_sockets_if_empty();
-    Configuration& operator=(Configuration const&) = default;
-    static Configuration INSTANCE;
+    Configuration& operator=(Configuration&&) = default;
+
+    static Configuration INSTANCE; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 };
 
 #include "ConfigParser.h"

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -9,12 +9,8 @@ class ConfigParser;
 
 class Configuration {
    public:
-    static Configuration& get_instance() {
-        return INSTANCE;
-    }
-    static void reset() {
-        INSTANCE = Configuration{};
-    }
+    static Configuration& get_instance() { return INSTANCE; }
+    static void reset() { INSTANCE = Configuration{}; }
     ~Configuration() = default;
     Configuration(Configuration const&) = delete;
     void apply_config_file(const ConfigParser& parser);

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -10,15 +10,18 @@ class ConfigParser;
 class Configuration {
    public:
     static Configuration& get_instance() {
-        static Configuration instance;
-        return instance;
+        return INSTANCE;
+    }
+    static void reset() {
+        INSTANCE = Configuration{};
     }
     ~Configuration() = default;
     Configuration(Configuration const&) = delete;
-    void operator=(Configuration const&) = delete;
     void apply_config_file(const ConfigParser& parser);
     void apply_environment();
+    void check_validity() const;
 
+    static const uint32_t DEFAULT_MIN_VNI;
     static const uint32_t DEFAULT_MAX_VNI;
     static const std::string DEFAULT_HAPD_SOCKDIR;
     static const std::string DEFAULT_HAPD_GROUP;
@@ -26,6 +29,7 @@ class Configuration {
     static const std::vector<std::string> DEFAULT_SOCKNAMES;
     static const uint32_t DEFAULT_CLEANUP_INTERVAL;
 
+    uint32_t min_vni = DEFAULT_MIN_VNI;
     uint32_t max_vni = DEFAULT_MAX_VNI;
     std::string hapd_sockdir = DEFAULT_HAPD_SOCKDIR;
     std::string hapd_group = DEFAULT_HAPD_GROUP;
@@ -36,6 +40,8 @@ class Configuration {
    private:
     Configuration() = default;
     void set_all_available_sockets_if_empty();
+    Configuration& operator=(Configuration const&) = default;
+    static Configuration INSTANCE;
 };
 
 #include "ConfigParser.h"

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -42,7 +42,7 @@ class Configuration {
     void set_all_available_sockets_if_empty();
     Configuration& operator=(Configuration&&) = default;
 
-    static Configuration INSTANCE; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+    static Configuration INSTANCE;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 };
 
 #include "ConfigParser.h"

--- a/src/Station.cpp
+++ b/src/Station.cpp
@@ -8,7 +8,13 @@
 Station::Station(std::string sockname, MacAddress mac)
     : vlan_id(std::nullopt), mac(std::move(mac)), sockname(std::move(sockname)) {}
 
-uint32_t Station::vni() const { return mac.number() % Configuration::get_instance().max_vni; }
+uint32_t Station::vni() const {
+    if (Configuration::get_instance().min_vni == Configuration::get_instance().max_vni) {
+        return Configuration::get_instance().min_vni;
+    }
+    return mac.number() % (Configuration::get_instance().max_vni - Configuration::get_instance().min_vni) +
+           Configuration::get_instance().min_vni;
+}
 
 std::string Station::vlan_interface_name() const { return "vlan" + std::to_string(vlan_id.value_or(0)); }
 

--- a/test/configuration_test.cpp
+++ b/test/configuration_test.cpp
@@ -5,9 +5,12 @@
 class ConfigurationTest : public testing::Test {
    public:
     static Configuration& from_string(const std::string& string) {
-        std::stringstream stream(string);
+        Configuration::reset();
         Configuration& config = Configuration::get_instance();
+
+        std::stringstream stream(string);
         config.apply_config_file(ConfigParser(stream));
+        config.check_validity();
         return config;
     }
 };
@@ -22,9 +25,18 @@ TEST(ConfigurationTest, EmptyConfiguration) {
     ASSERT_EQ(config.cleanup_interval, Configuration::DEFAULT_CLEANUP_INTERVAL);
 }
 
+TEST(ConfigurationTest, MinVNI) {
+    Configuration& config = ConfigurationTest::from_string("min_vni=3");
+    ASSERT_EQ(config.min_vni, 3);
+}
+
 TEST(ConfigurationTest, MaxVNI) {
     Configuration& config = ConfigurationTest::from_string("max_vni=5");
     ASSERT_EQ(config.max_vni, 5);
+}
+
+TEST(ConfigurationTest, MinVNIGreaterThanMaxVNI) {
+    EXPECT_THROW(ConfigurationTest::from_string("min_vni=6\nmax_vni=5"), std::runtime_error);
 }
 
 TEST(ConfigurationTest, HapdGroup) {

--- a/test/station_test.cpp
+++ b/test/station_test.cpp
@@ -4,7 +4,7 @@
 
 #include "Configuration.h"
 
-class StationTest : public testing::TestWithParam<std::tuple<MacAddress, uint32_t, uint32_t>> { };
+class StationTest : public testing::TestWithParam<std::tuple<MacAddress, uint32_t, uint32_t>> {};
 
 TEST_P(StationTest, VniIsWithinRange) {
     auto [mac, min_vni, max_vni] = StationTest::GetParam();
@@ -19,14 +19,10 @@ TEST_P(StationTest, VniIsWithinRange) {
     ASSERT_GE(max_vni, station.vni());
 }
 
-INSTANTIATE_TEST_SUITE_P(ExampleStationData, StationTest, testing::Combine(
-                                                              testing::Values(MacAddress("00:00:00:00:00:00"),
-                                                                              MacAddress("00:00:00:00:00:01"),
-                                                                              MacAddress("00:00:00:00:00:0F"),
-                                                                              MacAddress("00:00:00:00:00:20"),
-                                                                              MacAddress("00:00:00:00:04:00"),
-                                                                              MacAddress("00:00:00:00:80:00"),
-                                                                              MacAddress("01:00:00:00:00:00")),
-                                                              testing::Values(0, 1, 2, 3, 4, 5),
-                                                                testing::Values(0, 1, 2, 3, 4, 5)));
-
+INSTANTIATE_TEST_SUITE_P(
+    ExampleStationData, StationTest,
+    testing::Combine(testing::Values(MacAddress("00:00:00:00:00:00"), MacAddress("00:00:00:00:00:01"),
+                                     MacAddress("00:00:00:00:00:0F"), MacAddress("00:00:00:00:00:20"),
+                                     MacAddress("00:00:00:00:04:00"), MacAddress("00:00:00:00:80:00"),
+                                     MacAddress("01:00:00:00:00:00")),
+                     testing::Values(0, 1, 2, 3, 4, 5), testing::Values(0, 1, 2, 3, 4, 5)));

--- a/test/station_test.cpp
+++ b/test/station_test.cpp
@@ -1,0 +1,32 @@
+#include "Station.h"
+
+#include <gtest/gtest.h>
+
+#include "Configuration.h"
+
+class StationTest : public testing::TestWithParam<std::tuple<MacAddress, uint32_t, uint32_t>> { };
+
+TEST_P(StationTest, VniIsWithinRange) {
+    auto [mac, min_vni, max_vni] = StationTest::GetParam();
+    if (min_vni > max_vni) {
+        return;
+    }
+    Configuration &config = Configuration::get_instance();
+    config.min_vni = min_vni;
+    config.max_vni = max_vni;
+    Station station("wlan0", mac);
+    ASSERT_LE(min_vni, station.vni());
+    ASSERT_GE(max_vni, station.vni());
+}
+
+INSTANTIATE_TEST_SUITE_P(ExampleStationData, StationTest, testing::Combine(
+                                                              testing::Values(MacAddress("00:00:00:00:00:00"),
+                                                                              MacAddress("00:00:00:00:00:01"),
+                                                                              MacAddress("00:00:00:00:00:0F"),
+                                                                              MacAddress("00:00:00:00:00:20"),
+                                                                              MacAddress("00:00:00:00:04:00"),
+                                                                              MacAddress("00:00:00:00:80:00"),
+                                                                              MacAddress("01:00:00:00:00:00")),
+                                                              testing::Values(0, 1, 2, 3, 4, 5),
+                                                                testing::Values(0, 1, 2, 3, 4, 5)));
+


### PR DESCRIPTION
This PR adds a `min_vni` option. Closes #56.
It also improves test isolation by adding a static `reset` method to the `Configuration` singleton so tests can start with a fresh configuration.