### PR TITLE
Use git tag as openwrt package version on release

### DIFF
--- a/.github/workflows/build-openwrt.yml
+++ b/.github/workflows/build-openwrt.yml
@@ -8,6 +8,7 @@ on:
         type: string
       version:
         type: string
+        required: true
     secrets:
       ghtoken:
         required: true
@@ -19,6 +20,7 @@ jobs:
       packages: write
       contents: read
     steps:
+    - run: echo ${{ needs }}
     - uses: actions/checkout@v3
     - name: Extract metadata
       run: echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
@@ -45,6 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-env
     steps:
+      - run: echo ${{ needs }}
       - uses: actions/checkout@v3
       - name: Extract metadata
         run: echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV

--- a/.github/workflows/build-openwrt.yml
+++ b/.github/workflows/build-openwrt.yml
@@ -7,7 +7,6 @@ on:
         required: true
         type: string
       version:
-        type: map
     secrets:
       ghtoken:
         required: true

--- a/.github/workflows/build-openwrt.yml
+++ b/.github/workflows/build-openwrt.yml
@@ -6,7 +6,6 @@ on:
       architecture:
         required: true
         type: string
-      version:
     secrets:
       ghtoken:
         required: true

--- a/.github/workflows/build-openwrt.yml
+++ b/.github/workflows/build-openwrt.yml
@@ -7,7 +7,7 @@ on:
         required: true
         type: string
       version:
-        type: mapping
+        type: map
     secrets:
       ghtoken:
         required: true

--- a/.github/workflows/build-openwrt.yml
+++ b/.github/workflows/build-openwrt.yml
@@ -20,8 +20,6 @@ jobs:
       packages: write
       contents: read
     steps:
-    - run: echo ${{ needs.get-version.outputs }}
-    - run: echo ${{ inputs.version }}
     - uses: actions/checkout@v3
     - name: Extract metadata
       run: echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
@@ -43,12 +41,10 @@ jobs:
         cache-to: type=gha,mode=max,scope=$GITHUB_REF_NAME-${{ inputs.architecture }}
         build-args: |
           TAG=${{ inputs.architecture }}
-
   build:
     runs-on: ubuntu-latest
     needs: build-env
     steps:
-      - run: echo ${{ inputs.version }}
       - uses: actions/checkout@v3
       - name: Extract metadata
         run: echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV

--- a/.github/workflows/build-openwrt.yml
+++ b/.github/workflows/build-openwrt.yml
@@ -19,7 +19,8 @@ jobs:
       packages: write
       contents: read
     steps:
-    - run: echo ${{ needs }}
+    - run: echo ${{ needs.get-version.outputs }}
+    - run: echo ${{ inputs.version }}
     - uses: actions/checkout@v3
     - name: Extract metadata
       run: echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
@@ -46,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-env
     steps:
-      - run: echo ${{ version }}
+      - run: echo ${{ inputs.version }}
       - uses: actions/checkout@v3
       - name: Extract metadata
         run: echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV

--- a/.github/workflows/build-openwrt.yml
+++ b/.github/workflows/build-openwrt.yml
@@ -7,7 +7,7 @@ on:
         required: true
         type: string
       version:
-        type: string
+        type: mapping
     secrets:
       ghtoken:
         required: true

--- a/.github/workflows/build-openwrt.yml
+++ b/.github/workflows/build-openwrt.yml
@@ -7,6 +7,7 @@ on:
         required: true
         type: string
       version:
+        type: string
     secrets:
       ghtoken:
         required: true

--- a/.github/workflows/build-openwrt.yml
+++ b/.github/workflows/build-openwrt.yml
@@ -6,6 +6,9 @@ on:
       architecture:
         required: true
         type: string
+      version:
+        type: string
+        required: true
     secrets:
       ghtoken:
         required: true

--- a/.github/workflows/build-openwrt.yml
+++ b/.github/workflows/build-openwrt.yml
@@ -56,8 +56,8 @@ jobs:
           password: ${{ secrets.ghtoken }}
       - name: Build OpenWrt
         env:
-          - IMAGE="ghcr.io/wimove-oss/wimove/wimove-buildenv/${{ inputs.architecture }}:${{ env.BRANCH }}"
-          - VERSION="${{ inputs.version }}"
+          IMAGE: "ghcr.io/wimove-oss/wimove/wimove-buildenv/${{ inputs.architecture }}:${{ env.BRANCH }}"
+          VERSION: "${{ inputs.version }}"
         run: chmod +x ./openwrt/build-openwrt.sh && ./openwrt/build-openwrt.sh
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-openwrt.yml
+++ b/.github/workflows/build-openwrt.yml
@@ -6,6 +6,8 @@ on:
       architecture:
         required: true
         type: string
+      version:
+        type: string
     secrets:
       ghtoken:
         required: true
@@ -53,7 +55,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.ghtoken }}
       - name: Build OpenWrt
-        run: export IMAGE="ghcr.io/wimove-oss/wimove/wimove-buildenv/${{ inputs.architecture }}:${{ env.BRANCH }}" && chmod +x ./openwrt/build-openwrt.sh && ./openwrt/build-openwrt.sh
+        env:
+          - IMAGE="ghcr.io/wimove-oss/wimove/wimove-buildenv/${{ inputs.architecture }}:${{ env.BRANCH }}"
+          - VERSION="${{ inputs.version }}"
+        run: chmod +x ./openwrt/build-openwrt.sh && ./openwrt/build-openwrt.sh
       - uses: actions/upload-artifact@v3
         with:
           name: wimove-${{ inputs.architecture }}

--- a/.github/workflows/build-openwrt.yml
+++ b/.github/workflows/build-openwrt.yml
@@ -7,8 +7,6 @@ on:
         required: true
         type: string
       version:
-        type: string
-        required: true
     secrets:
       ghtoken:
         required: true
@@ -47,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-env
     steps:
-      - run: echo ${{ needs }}
+      - run: echo ${{ version }}
       - uses: actions/checkout@v3
       - name: Extract metadata
         run: echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,8 @@ jobs:
 
   debug:
     runs-on: ubuntu-latest
+    needs:
+      [get-new-version]
     steps:
       - run: echo ${{ needs.get-new-version.outputs }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,31 +8,7 @@ on:
 
 jobs:
   get-version:
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: read
-    outputs:
-      version: ${{ steps.step1.outputs.version }}
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: 'Get Previous tag'
-        id: previoustag
-        uses: "WyriHaximus/github-action-get-previous-tag@v1"
-        with:
-          #fallback: 1.0.0 # Optional fallback tag to use when no tag can be found
-          prefix: "v"
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-      - name: 'Get next minor version'
-        id: semvers
-        uses: "WyriHaximus/github-action-next-semvers@v1"
-        with:
-          version: ${{ steps.previoustag.outputs.tag }}
-      - id: step1
-        run: echo "version=${{ steps.semvers.outputs.v_patch }}+beta$(date '+%Y-%m-%d_%H.%M')" >> "$GITHUB_OUTPUT"
+    uses: ./.github/workflows/get-version.yml
   build-arm:
     permissions:
       packages: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     needs:
       [get-new-version]
     steps:
-      - run: echo ${{ needs.get-new-version.outputs }}
+      - run: echo ${{ needs.get-new-version.outputs.version }}
 
   build-arm:
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   get-version:
+    permissions:
+      contents: read
     uses: ./.github/workflows/get-version.yml
   build-arm:
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,9 +31,8 @@ jobs:
         uses: "WyriHaximus/github-action-next-semvers@v1"
         with:
           version: ${{ steps.previoustag.outputs.tag }}
-      - run: echo "${{ steps.previoustag.outputs.tag }}"
       - id: step1
-        run: echo "version=${{ steps.semvers.outputs.v_patch }}" >> "$GITHUB_OUTPUT"
+        run: echo "version=${{ steps.semvers.outputs.v_patch }}+beta$(date '+%Y-%m-%d_%H.%M')" >> "$GITHUB_OUTPUT"
   build-arm:
     permissions:
       packages: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,8 @@ jobs:
         id: semvers
         uses: "WyriHaximus/github-action-next-semvers@v1"
         with:
-          version: ${{ steps.semvers.outputs.v_patch }}
-      - run: echo "${{ steps.semvers.outputs.v_patch }}"
+          version: ${{ steps.previoustag.outputs.tag }}
+      - run: echo "${{ steps.previoustag.outputs.tag }}"
       - id: step1
         run: echo "version=${{ steps.semvers.outputs.v_patch }}" >> "$GITHUB_OUTPUT"
   build-arm:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
     outputs:
       version: ${{ steps.step1.outputs.version }}
     steps:
+      - uses: actions/checkout@v3
       - name: 'Get Previous tag'
         id: previoustag
         uses: "WyriHaximus/github-action-get-previous-tag@v1"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,15 +7,6 @@ on:
       - "main"
 
 jobs:
-  job1:
-    uses: ./.github/workflows/get-version.yml
-
-  job2:
-    runs-on: ubuntu-latest
-    needs: job1
-    steps:
-      - run: echo ${{ needs.job1.outputs.firstword }} ${{ needs.job1.outputs.secondword }}
-      - run: echo ${{ needs.job1.outputs.version }} ${{ needs.job1.outputs.secondword }}
 
   get-new-version:
     permissions:
@@ -28,7 +19,6 @@ jobs:
       [get-new-version]
     steps:
       - run: echo ${{ needs.get-new-version.outputs.version }}
-      - run: echo ${{ needs.get-version.outputs.version }}
 
   build-arm:
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
     uses: ./.github/workflows/build-openwrt.yml
     with:
       architecture: mvebu-cortexa9-22.03.3
-      version: ${{needs.get-new-version.outputs }}
+      version: ${{ needs.get-new-version.outputs.version }}
     secrets:
       ghtoken: ${{ secrets.GITHUB_TOKEN }}
   build-ramips:
@@ -41,6 +41,6 @@ jobs:
     uses: ./.github/workflows/build-openwrt.yml
     with:
       architecture: ramips-mt7621-22.03.3
-      version: ${{needs.get-new-version.outputs }}
+      version: ${{ needs.get-new-version.outputs.version }}
     secrets:
       ghtoken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,11 @@ jobs:
       contents: read
     uses: ./.github/workflows/get-version.yml
 
+  debug:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ${{ needs.get-new-version.outputs }}
+
   build-arm:
     permissions:
       packages: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
         uses: "WyriHaximus/github-action-get-previous-tag@v1"
         with:
           fallback: 1.0.0 # Optional fallback tag to use when no tag can be found
+          prefix: "v"
       - name: 'Get next minor version'
         id: semvers
         uses: "WyriHaximus/github-action-next-semvers@v1"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,9 +21,9 @@ jobs:
       - name: 'Get Previous tag'
         id: previoustag
         uses: "WyriHaximus/github-action-get-previous-tag@v1"
-        #with:
-        #  #fallback: 1.0.0 # Optional fallback tag to use when no tag can be found
-        #  prefix: "v"
+        with:
+          #fallback: 1.0.0 # Optional fallback tag to use when no tag can be found
+          prefix: "v"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: 'Get next minor version'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,15 @@ on:
       - "main"
 
 jobs:
+  job1:
+    uses: ./.github/workflows/get-version.yml
+
+  job2:
+    runs-on: ubuntu-latest
+    needs: job1
+    steps:
+      - run: echo ${{ needs.job1.outputs.firstword }} ${{ needs.job1.outputs.secondword }}
+
   get-new-version:
     permissions:
       contents: read
@@ -18,6 +27,7 @@ jobs:
       [get-new-version]
     steps:
       - run: echo ${{ needs.get-new-version.outputs.version }}
+      - run: echo ${{ needs.get-version.outputs.version }}
 
   build-arm:
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,9 @@ jobs:
       - name: 'Get Previous tag'
         id: previoustag
         uses: "WyriHaximus/github-action-get-previous-tag@v1"
-        with:
-          fallback: 1.0.0 # Optional fallback tag to use when no tag can be found
-          prefix: "v"
+        #with:
+        #  #fallback: 1.0.0 # Optional fallback tag to use when no tag can be found
+        #  prefix: "v"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: 'Get next minor version'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
     needs: job1
     steps:
       - run: echo ${{ needs.job1.outputs.firstword }} ${{ needs.job1.outputs.secondword }}
+      - run: echo ${{ needs.job1.outputs.version }} ${{ needs.job1.outputs.secondword }}
 
   get-new-version:
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,8 @@ jobs:
       version: ${{ steps.step1.outputs.version }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: 'Get Previous tag'
         id: previoustag
         uses: "WyriHaximus/github-action-get-previous-tag@v1"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,17 +8,9 @@ on:
 
 jobs:
   get-version:
-    runs-on: ubuntu-latest
     permissions:
       contents: read
-    outputs:
-      version: ${{ steps.step1.outputs.version }}
-    steps:
-      - uses: actions/checkout@v3
-      - id: get
-        uses: ./.github/workflows/get-version.yml
-      - id: step1
-        run: echo "version=${{ steps.get.outputs.version }}" >> "$GITHUB_OUTPUT"
+    uses: ./.github/workflows/get-version.yml
 
   build-arm:
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,22 +7,47 @@ on:
       - "main"
 
 jobs:
+  get-version:
+    permissions:
+      packages: write
+      contents: read
+    outputs:
+      version: ${{ steps.step1.outputs.version }}
+    steps:
+      - name: 'Get Previous tag'
+        id: previoustag
+        uses: "WyriHaximus/github-action-get-previous-tag@v1"
+        with:
+          fallback: 1.0.0 # Optional fallback tag to use when no tag can be found
+      - name: 'Get next minor version'
+        id: semvers
+        uses: "WyriHaximus/github-action-next-semvers@v1"
+        with:
+          version: ${{ steps.semvers.outputs.v_patch }}
+      - run: echo "${{ steps.semvers.outputs.v_patch }}"
+      - id: step1
+        run: echo "version=${{ steps.semvers.outputs.v_patch }}" >> "$GITHUB_OUTPUT"
   build-arm:
     permissions:
       packages: write
       contents: read
+    needs:
+      [get-version]
     uses: ./.github/workflows/build-openwrt.yml
     with:
       architecture: mvebu-cortexa9-22.03.3
+      version: ${{needs.get-version.outputs.version }}
     secrets:
       ghtoken: ${{ secrets.GITHUB_TOKEN }}
-
   build-ramips:
     permissions:
       packages: write
       contents: read
+    needs:
+      [get-version]
     uses: ./.github/workflows/build-openwrt.yml
     with:
       architecture: ramips-mt7621-22.03.3
+      version: ${{needs.get-version.outputs.version }}
     secrets:
       ghtoken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   get-version:
+    runs-on: ubuntu-latest
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     uses: ./.github/workflows/build-openwrt.yml
     with:
       architecture: mvebu-cortexa9-22.03.3
-      version: ${{needs.get-new-version.outputs.version }}
+      version: ${{needs.get-new-version.outputs }}
     secrets:
       ghtoken: ${{ secrets.GITHUB_TOKEN }}
   build-ramips:
@@ -33,6 +33,6 @@ jobs:
     uses: ./.github/workflows/build-openwrt.yml
     with:
       architecture: ramips-mt7621-22.03.3
-      version: ${{needs.get-new-version.outputs.version }}
+      version: ${{needs.get-new-version.outputs }}
     secrets:
       ghtoken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   get-version:
+    runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.step1.outputs.version }}
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,16 @@ on:
 
 jobs:
   get-version:
+    outputs:
+      version: ${{ steps.step1.outputs.version }}
     permissions:
       contents: read
-    uses: ./.github/workflows/get-version.yml
+    steps:
+      - id: semver
+        uses: ./.github/workflows/get-version.yml
+      - run: echo "${{ steps.semver.outputs.version}}"
+      - id: step1
+        run: echo "version=${{ steps.semver.outputs.version}}" >> "$GITHUB_OUTPUT"
   build-arm:
     permissions:
       packages: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,19 +7,10 @@ on:
       - "main"
 
 jobs:
-
   get-new-version:
     permissions:
       contents: read
     uses: ./.github/workflows/get-version.yml
-
-  debug:
-    runs-on: ubuntu-latest
-    needs:
-      [get-new-version]
-    steps:
-      - run: echo ${{ needs.get-new-version.outputs.version }}
-
   build-arm:
     permissions:
       packages: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
       - "main"
 
 jobs:
-  get-version:
+  get-new-version:
     permissions:
       contents: read
     uses: ./.github/workflows/get-version.yml
@@ -17,11 +17,11 @@ jobs:
       packages: write
       contents: read
     needs:
-      [get-version]
+      [get-new-version]
     uses: ./.github/workflows/build-openwrt.yml
     with:
       architecture: mvebu-cortexa9-22.03.3
-      version: ${{needs.get-version.outputs.version }}
+      version: ${{needs.get-new-version.outputs.version }}
     secrets:
       ghtoken: ${{ secrets.GITHUB_TOKEN }}
   build-ramips:
@@ -29,10 +29,10 @@ jobs:
       packages: write
       contents: read
     needs:
-      [get-version]
+      [get-new-version]
     uses: ./.github/workflows/build-openwrt.yml
     with:
       architecture: ramips-mt7621-22.03.3
-      version: ${{needs.get-version.outputs.version }}
+      version: ${{needs.get-new-version.outputs.version }}
     secrets:
       ghtoken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,8 @@ jobs:
         with:
           fallback: 1.0.0 # Optional fallback tag to use when no tag can be found
           prefix: "v"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: 'Get next minor version'
         id: semvers
         uses: "WyriHaximus/github-action-next-semvers@v1"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ jobs:
     outputs:
       version: ${{ steps.step1.outputs.version }}
     steps:
+      - uses: actions/checkout@v3
       - id: get
         uses: ./.github/workflows/get-version.yml
       - id: step1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,16 +9,16 @@ on:
 jobs:
   get-version:
     runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.step1.outputs.version }}
     permissions:
       contents: read
+    outputs:
+      version: ${{ steps.step1.outputs.version }}
     steps:
-      - id: semver
+      - id: get
         uses: ./.github/workflows/get-version.yml
-      - run: echo "${{ steps.semver.outputs.version}}"
       - id: step1
-        run: echo "version=${{ steps.semver.outputs.version}}" >> "$GITHUB_OUTPUT"
+        run: echo "version=${{ steps.get.outputs.version }}" >> "$GITHUB_OUTPUT"
+
   build-arm:
     permissions:
       packages: write

--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -21,14 +21,14 @@ on:
         value: ${{ jobs.example_job.outputs.output2 }}
       version:
         description: "The second output string"
-        value: ${{ jobs.get-version.outputs.output1 }}
+        value: ${{ jobs.get-version.outputs.version }}
 jobs:
   get-version:
     runs-on: ubuntu-latest
     permissions:
       contents: read
     outputs:
-      output1: ${{ steps.step1.outputs.version }}
+      version: ${{ steps.step1.outputs.version }}
     steps:
       #- uses: actions/checkout@v3
       #  with:

--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -1,34 +1,64 @@
-name: Get next semversion
+#name: Get next semversion
+#
+#on:
+#  workflow_call:
+#    outputs:
+#      version:
+#        description: "The next version string"
+#        value: ${{ jobs.get-version.version }}
+#
+#jobs:
+#  get-version:
+#    runs-on: ubuntu-latest
+#    permissions:
+#      contents: read
+#    outputs:
+#      version: ${{ steps.step1.outputs.version }}
+#    steps:
+#      #- uses: actions/checkout@v3
+#      #  with:
+#      #    fetch-depth: 0
+#      #- name: 'Get Previous tag'
+#      #  id: previoustag
+#      #  uses: "WyriHaximus/github-action-get-previous-tag@v1"
+#      #  with:
+#      #    prefix: "v"
+#      #  env:
+#      #    GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+#      #- name: 'Get next minor version'
+#      #  id: semvers
+#      #  uses: "WyriHaximus/github-action-next-semvers@v1"
+#      #  with:
+#      #    version: ${{ steps.previoustag.outputs.tag }}
+#      #- id: step1
+#      #  run: echo "version=${{ steps.semvers.outputs.v_patch }}+beta$(date '+%Y-%m-%d_%H.%M')" >> "$GITHUB_OUTPUT"
+#      - id: step1
+#        run: echo "version=test1" >> "$GITHUB_OUTPUT"
+#
+#
+name: Reusable workflow
 
 on:
   workflow_call:
+    # Map the workflow outputs to job outputs
     outputs:
-      version:
-        description: "The next version string"
-        value: ${{ jobs.get-version.version }}
+      firstword:
+        description: "The first output string"
+        value: ${{ jobs.example_job.outputs.output1 }}
+      secondword:
+        description: "The second output string"
+        value: ${{ jobs.example_job.outputs.output2 }}
 
 jobs:
-  get-version:
+  example_job:
+    name: Generate output
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
+    # Map the job outputs to step outputs
     outputs:
-      version: ${{ steps.step1.outputs.version }}
+      output1: ${{ steps.step1.outputs.firstword }}
+      output2: ${{ steps.step2.outputs.secondword }}
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: 'Get Previous tag'
-        id: previoustag
-        uses: "WyriHaximus/github-action-get-previous-tag@v1"
-        with:
-          prefix: "v"
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-      - name: 'Get next minor version'
-        id: semvers
-        uses: "WyriHaximus/github-action-next-semvers@v1"
-        with:
-          version: ${{ steps.previoustag.outputs.tag }}
       - id: step1
-        run: echo "version=${{ steps.semvers.outputs.v_patch }}+beta$(date '+%Y-%m-%d_%H.%M')" >> "$GITHUB_OUTPUT"
+        run: echo "firstword=hello" >> $GITHUB_OUTPUT
+      - id: step2
+        run: echo "secondword=world" >> $GITHUB_OUTPUT

--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -7,7 +7,6 @@ jobs:
   get-version:
     runs-on: ubuntu-latest
     permissions:
-      packages: write
       contents: read
     outputs:
       version: ${{ steps.step1.outputs.version }}

--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -1,26 +1,11 @@
-#name: Get next semversion
-#
-#on:
-#  workflow_call:
-#    outputs:
-#      version:
-#        description: "The next version string"
-#        value: ${{ jobs.get-version.version }}
-#
-name: Reusable workflow
+name: Get next semversion
 
 on:
   workflow_call:
     # Map the workflow outputs to job outputs
     outputs:
-      firstword:
-        description: "The first output string"
-        value: ${{ jobs.example_job.outputs.output1 }}
-      secondword:
-        description: "The second output string"
-        value: ${{ jobs.example_job.outputs.output2 }}
       version:
-        description: "The second output string"
+        description: "The output version"
         value: ${{ jobs.get-version.outputs.version }}
 jobs:
   get-version:
@@ -30,34 +15,20 @@ jobs:
     outputs:
       version: ${{ steps.step1.outputs.version }}
     steps:
-      #- uses: actions/checkout@v3
-      #  with:
-      #    fetch-depth: 0
-      #- name: 'Get Previous tag'
-      #  id: previoustag
-      #  uses: "WyriHaximus/github-action-get-previous-tag@v1"
-      #  with:
-      #    prefix: "v"
-      #  env:
-      #    GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-      #- name: 'Get next minor version'
-      #  id: semvers
-      #  uses: "WyriHaximus/github-action-next-semvers@v1"
-      #  with:
-      #    version: ${{ steps.previoustag.outputs.tag }}
-      #- id: step1
-      #  run: echo "version=${{ steps.semvers.outputs.v_patch }}+beta$(date '+%Y-%m-%d_%H.%M')" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: 'Get Previous tag'
+        id: previoustag
+        uses: "WyriHaximus/github-action-get-previous-tag@v1"
+        with:
+          prefix: "v"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: 'Get next minor version'
+        id: semvers
+        uses: "WyriHaximus/github-action-next-semvers@v1"
+        with:
+          version: ${{ steps.previoustag.outputs.tag }}
       - id: step1
-        run: echo "version=test1" >> "$GITHUB_OUTPUT"
-  example_job:
-    name: Generate output
-    runs-on: ubuntu-latest
-    # Map the job outputs to step outputs
-    outputs:
-      output1: ${{ steps.step1.outputs.firstword }}
-      output2: ${{ steps.step2.outputs.secondword }}
-    steps:
-      - id: step1
-        run: echo "firstword=hello" >> $GITHUB_OUTPUT
-      - id: step2
-        run: echo "secondword=world" >> $GITHUB_OUTPUT
+        run: echo "version=${{ steps.semvers.outputs.v_patch }}+beta$(date '+%Y-%m-%d_%H.%M')" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -2,6 +2,10 @@ name: Get next semversion
 
 on:
   workflow_call:
+    outputs:
+      version:
+        description: "The next version string"
+        value: ${{ jobs.get-version.version }}
 
 jobs:
   get-version:

--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -48,6 +48,9 @@ on:
       secondword:
         description: "The second output string"
         value: ${{ jobs.example_job.outputs.output2 }}
+      version:
+        description: "The second output string"
+        value: ${{ jobs.example_job.outputs.output2 }}
 
 jobs:
   example_job:

--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -1,0 +1,31 @@
+name: Get next semversion
+
+on:
+  workflow_call:
+
+jobs:
+  get-version:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    outputs:
+      version: ${{ steps.step1.outputs.version }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: 'Get Previous tag'
+        id: previoustag
+        uses: "WyriHaximus/github-action-get-previous-tag@v1"
+        with:
+          prefix: "v"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: 'Get next minor version'
+        id: semvers
+        uses: "WyriHaximus/github-action-next-semvers@v1"
+        with:
+          version: ${{ steps.previoustag.outputs.tag }}
+      - id: step1
+        run: echo "version=${{ steps.semvers.outputs.v_patch }}+beta$(date '+%Y-%m-%d_%H.%M')" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -7,35 +7,6 @@
 #        description: "The next version string"
 #        value: ${{ jobs.get-version.version }}
 #
-#jobs:
-#  get-version:
-#    runs-on: ubuntu-latest
-#    permissions:
-#      contents: read
-#    outputs:
-#      version: ${{ steps.step1.outputs.version }}
-#    steps:
-#      #- uses: actions/checkout@v3
-#      #  with:
-#      #    fetch-depth: 0
-#      #- name: 'Get Previous tag'
-#      #  id: previoustag
-#      #  uses: "WyriHaximus/github-action-get-previous-tag@v1"
-#      #  with:
-#      #    prefix: "v"
-#      #  env:
-#      #    GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-#      #- name: 'Get next minor version'
-#      #  id: semvers
-#      #  uses: "WyriHaximus/github-action-next-semvers@v1"
-#      #  with:
-#      #    version: ${{ steps.previoustag.outputs.tag }}
-#      #- id: step1
-#      #  run: echo "version=${{ steps.semvers.outputs.v_patch }}+beta$(date '+%Y-%m-%d_%H.%M')" >> "$GITHUB_OUTPUT"
-#      - id: step1
-#        run: echo "version=test1" >> "$GITHUB_OUTPUT"
-#
-#
 name: Reusable workflow
 
 on:
@@ -50,9 +21,34 @@ on:
         value: ${{ jobs.example_job.outputs.output2 }}
       version:
         description: "The second output string"
-        value: ${{ jobs.example_job.outputs.output2 }}
-
+        value: ${{ jobs.get-version.outputs.output1 }}
 jobs:
+  get-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      output1: ${{ steps.step1.outputs.version }}
+    steps:
+      #- uses: actions/checkout@v3
+      #  with:
+      #    fetch-depth: 0
+      #- name: 'Get Previous tag'
+      #  id: previoustag
+      #  uses: "WyriHaximus/github-action-get-previous-tag@v1"
+      #  with:
+      #    prefix: "v"
+      #  env:
+      #    GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      #- name: 'Get next minor version'
+      #  id: semvers
+      #  uses: "WyriHaximus/github-action-next-semvers@v1"
+      #  with:
+      #    version: ${{ steps.previoustag.outputs.tag }}
+      #- id: step1
+      #  run: echo "version=${{ steps.semvers.outputs.v_patch }}+beta$(date '+%Y-%m-%d_%H.%M')" >> "$GITHUB_OUTPUT"
+      - id: step1
+        run: echo "version=test1" >> "$GITHUB_OUTPUT"
   example_job:
     name: Generate output
     runs-on: ubuntu-latest

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -9,6 +9,8 @@ on:
       - "*"
 jobs:
   get-version:
+    permissions:
+      contents: read
     uses: ./.github/workflows/get-version.yml
   build-arm:
     permissions:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -7,28 +7,33 @@ on:
       - "main"
     tags-ignore:
       - "*"
-
 jobs:
+  get-version:
+    uses: ./.github/workflows/get-version.yml
   build-arm:
     permissions:
       packages: write
       contents: read
+    needs:
+      [get-version]
     uses: ./.github/workflows/build-openwrt.yml
     with:
       architecture: mvebu-cortexa9-22.03.3
+      version: ${{needs.get-version.outputs.version }}
     secrets:
       ghtoken: ${{ secrets.GITHUB_TOKEN }}
-
   build-ramips:
     permissions:
       packages: write
       contents: read
+    needs:
+      [get-version]
     uses: ./.github/workflows/build-openwrt.yml
     with:
       architecture: ramips-mt7621-22.03.3
+      version: ${{needs.get-version.outputs.version }}
     secrets:
       ghtoken: ${{ secrets.GITHUB_TOKEN }}
-
   pre-release:
     needs: [build-ramips, build-arm]
     runs-on: "ubuntu-latest"
@@ -39,11 +44,6 @@ jobs:
       - uses: actions/download-artifact@v3
       - name: Move all files into current working directory
         run: "mv */*.ipk ."
-      - name: Rename Files to contain commit hash
-        run: |
-          for file in *.ipk; do
-            mv "$file" "${file%.ipk}_${{ github.sha }}.ipk"
-          done
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -21,7 +21,7 @@ jobs:
     uses: ./.github/workflows/build-openwrt.yml
     with:
       architecture: mvebu-cortexa9-22.03.3
-      version: ${{needs.get-version.outputs.version }}
+      version: ${{ needs.get-version.outputs.version }}
     secrets:
       ghtoken: ${{ secrets.GITHUB_TOKEN }}
   build-ramips:
@@ -33,7 +33,7 @@ jobs:
     uses: ./.github/workflows/build-openwrt.yml
     with:
       architecture: ramips-mt7621-22.03.3
-      version: ${{needs.get-version.outputs.version }}
+      version: ${{ needs.get-version.outputs.version }}
     secrets:
       ghtoken: ${{ secrets.GITHUB_TOKEN }}
   pre-release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,23 +11,32 @@ jobs:
     permissions:
       packages: write
       contents: read
-    uses: ./.github/workflows/build-openwrt.yml
-    with:
-      architecture: mvebu-cortexa9-22.03.3
-    secrets:
-      ghtoken: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Set env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - uses: ./.github/workflows/build-openwrt.yml
+        with:
+          architecture: mvebu-cortexa9-22.03.3
+          version: ${{ env.RELEASE_VERSION }}
+        secrets:
+          ghtoken: ${{ secrets.GITHUB_TOKEN }}
 
   build-ramips:
     permissions:
       packages: write
       contents: read
-    uses: ./.github/workflows/build-openwrt.yml
-    with:
-      architecture: ramips-mt7621-22.03.3
-    secrets:
-      ghtoken: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Set env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - uses: ./.github/workflows/build-openwrt.yml
+        with:
+          architecture: ramips-mt7621-22.03.3
+          version: ${{ env.RELEASE_VERSION }}
+        secrets:
+          ghtoken: ${{ secrets.GITHUB_TOKEN }}
 
-  pre-release:
+  release:
     needs: [build-ramips, build-arm]
     runs-on: "ubuntu-latest"
     permissions:
@@ -37,11 +46,6 @@ jobs:
       - uses: actions/download-artifact@v3
       - name: Move all files into current working directory
         run: "mv */*.ipk ."
-      - name: Rename Files to contain commit hash
-        run: |
-          for file in *.ipk; do
-            mv "$file" "${file%.ipk}_${{ github.sha }}.ipk"
-          done
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
 
     steps:
-      - name: Set env
+      - name: Set tag
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - uses: ./.github/workflows/build-openwrt.yml
         with:
@@ -27,7 +27,7 @@ jobs:
       packages: write
       contents: read
     steps:
-      - name: Set env
+      - name: Set tag
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - uses: ./.github/workflows/build-openwrt.yml
         with:

--- a/docker/openwrt-build-env/Dockerfile
+++ b/docker/openwrt-build-env/Dockerfile
@@ -15,5 +15,3 @@ RUN ./scripts/feeds update && \
     rm -rf feeds
 
 CMD bash /home/build/build-wimoved.sh
-
-

--- a/openwrt/build-openwrt.sh
+++ b/openwrt/build-openwrt.sh
@@ -2,7 +2,7 @@
 mkdir -p out || true
 chmod -R ogu+rw out
 docker run --rm \
-  -e PKG_VERSION="$(VERSION)+beta$(date '+%Y-%m-%d-%H.%M.%S')" \
+  -e PKG_VERSION="$($VERSION)+beta$(date '+%Y-%m-%d-%H.%M.%S')" \
   -v "$(pwd)"/openwrt/package:/home/build/openwrt/package/network/services/wimoved \
   -v "$(pwd)"/CMakeLists.txt:/home/build/openwrt/package/network/services/wimoved/src/CMakeLists.txt \
   -v "$(pwd)"/vendor:/home/build/openwrt/package/network/services/wimoved/src/vendor \

--- a/openwrt/build-openwrt.sh
+++ b/openwrt/build-openwrt.sh
@@ -2,9 +2,10 @@
 mkdir -p out || true
 chmod -R ogu+rw out
 docker run --rm \
+  -e PKG_VERSION="$(VERSION)+beta$(date '+%Y-%m-%d-%H.%M.%S')" \
   -v "$(pwd)"/openwrt/package:/home/build/openwrt/package/network/services/wimoved \
   -v "$(pwd)"/CMakeLists.txt:/home/build/openwrt/package/network/services/wimoved/src/CMakeLists.txt \
   -v "$(pwd)"/vendor:/home/build/openwrt/package/network/services/wimoved/src/vendor \
   -v "$(pwd)"/src:/home/build/openwrt/package/network/services/wimoved/src/src \
   -v "$(pwd)"/out:/home/build/openwrt/out \
-  $IMAGE
+  "$($IMAGE)"

--- a/openwrt/build-openwrt.sh
+++ b/openwrt/build-openwrt.sh
@@ -2,10 +2,10 @@
 mkdir -p out || true
 chmod -R ogu+rw out
 docker run --rm \
-  -e PKG_VERSION="$($VERSION)+beta$(date '+%Y-%m-%d-%H.%M.%S')" \
+  -e PKG_VERSION="$VERSION+beta$(date '+%Y-%m-%d-%H.%M.%S')" \
   -v "$(pwd)"/openwrt/package:/home/build/openwrt/package/network/services/wimoved \
   -v "$(pwd)"/CMakeLists.txt:/home/build/openwrt/package/network/services/wimoved/src/CMakeLists.txt \
   -v "$(pwd)"/vendor:/home/build/openwrt/package/network/services/wimoved/src/vendor \
   -v "$(pwd)"/src:/home/build/openwrt/package/network/services/wimoved/src/src \
   -v "$(pwd)"/out:/home/build/openwrt/out \
-  "$($IMAGE)"
+  "$IMAGE"

--- a/openwrt/build-openwrt.sh
+++ b/openwrt/build-openwrt.sh
@@ -2,7 +2,7 @@
 mkdir -p out || true
 chmod -R ogu+rw out
 docker run --rm \
-  -e PKG_VERSION="$VERSION+beta$(date '+%Y-%m-%d_%H.%M')" \
+  -e PKG_VERSION="$VERSION" \
   -v "$(pwd)"/openwrt/package:/home/build/openwrt/package/network/services/wimoved \
   -v "$(pwd)"/CMakeLists.txt:/home/build/openwrt/package/network/services/wimoved/src/CMakeLists.txt \
   -v "$(pwd)"/vendor:/home/build/openwrt/package/network/services/wimoved/src/vendor \

--- a/openwrt/build-openwrt.sh
+++ b/openwrt/build-openwrt.sh
@@ -2,7 +2,7 @@
 mkdir -p out || true
 chmod -R ogu+rw out
 docker run --rm \
-  -e PKG_VERSION="$VERSION+beta$(date '+%Y-%m-%d-%H.%M.%S')" \
+  -e PKG_VERSION="$VERSION+beta$(date '+%Y-%m-%d_%H.%M')" \
   -v "$(pwd)"/openwrt/package:/home/build/openwrt/package/network/services/wimoved \
   -v "$(pwd)"/CMakeLists.txt:/home/build/openwrt/package/network/services/wimoved/src/CMakeLists.txt \
   -v "$(pwd)"/vendor:/home/build/openwrt/package/network/services/wimoved/src/vendor \

--- a/openwrt/package/Makefile
+++ b/openwrt/package/Makefile
@@ -5,6 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wimoved
 PKG_RELEASE:=1
+PKG_VERSION?=1
 
 PKG_FLAGS:=nonshared
 PKG_LICENSE:=MIT


### PR DESCRIPTION
For all commits on branches that do not have a tag starting with `v` we build a package with the next patch semversioning number and a timestamp. This allows that newer packages will overwrite older packages. 