### PR TITLE
Disable MAC learning on the VXLAN interface

### DIFF
--- a/src/nl/Socket.cpp
+++ b/src/nl/Socket.cpp
@@ -46,6 +46,10 @@ void nl::Socket::create_vxlan_iface(uint32_t vni) {
         throw std::runtime_error(std::string("error in rtnl_link_vxlan_set_id: ") + std::strerror(errno));
     }
 
+    if (rtnl_link_vxlan_set_learning(vxlan.link, 0)) {
+        throw std::runtime_error(std::string("error in rtnl_link_vxlan_set_learning: ") + std::strerror(errno));
+    }
+
     int err = rtnl_link_vxlan_set_port(vxlan.link, VXLAN_PORT);
     if (err < 0) {
         throw std::runtime_error(std::string("error in rtnl_link_vxlan_set_port_range: ") + nl_geterror(err));

--- a/src/nl/Socket.cpp
+++ b/src/nl/Socket.cpp
@@ -46,7 +46,7 @@ void nl::Socket::create_vxlan_iface(uint32_t vni) {
         throw std::runtime_error(std::string("error in rtnl_link_vxlan_set_id: ") + std::strerror(errno));
     }
 
-    if (rtnl_link_vxlan_set_learning(vxlan.link, 0)) {
+    if (rtnl_link_vxlan_set_learning(vxlan.link, 0) < 0) {
         throw std::runtime_error(std::string("error in rtnl_link_vxlan_set_learning: ") + std::strerror(errno));
     }
 


### PR DESCRIPTION
The VXLAN interfaces should not perform data-plane MAC learning. This PR disables that feature when creating new interfaces. 